### PR TITLE
Enable color in clang-format output

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -9,4 +9,4 @@ dry_run=$5
 
 test -e .clang-format || ln -s -f $config .clang-format
 
-$binary --fcolor-diagnostics --Werror $dry_run $infile > $outfile
+$binary --color=true --Werror $dry_run $infile > $outfile


### PR DESCRIPTION
By default the output is not colorized because a redirection to a file is detected by the clang-format. The `--fcolor-diagnostics` flag only brings back the default behavior:
> If set, **and** on a color-capable terminal controls whether or not to print diagnostics in color

To force colored output to non-interactive terminal the `--color=true` option has to be passed. I don't see a reason to not include it in this default wrapper.