### PR TITLE
use default shell env when executing ClangFormat

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -41,6 +41,7 @@ touch {outfile}
         ),
         mnemonic = "ClangFormat",
         progress_message = "Formatting {}".format(f.short_path),
+        use_default_shell_env = True,
         execution_requirements = execution_reqs,
     )
 


### PR DESCRIPTION
This ensures that changes to the shell env (e.g. setting `PATH`) are
propagated to the action.

Change-Id: If555685b0ad8b7ed61c04535ca1e91c5a32028be